### PR TITLE
Add additional APIs for requesting more specific details of zones and records

### DIFF
--- a/src/erldns_admin.erl
+++ b/src/erldns_admin.erl
@@ -63,6 +63,7 @@ init([]) ->
         [
           {"/", erldns_admin_root_handler, []},
           {"/zones/:name", erldns_admin_zone_resource_handler, []},
+          {"/zones/:zone_name/records", erldns_admin_zone_records_resource_handler, []},
           {"/zones/:zone_name/records/:record_name", erldns_admin_zone_records_resource_handler, []},
           {"/zones/:name/:action", erldns_admin_zone_control_handler, []}
         ]

--- a/src/erldns_admin.erl
+++ b/src/erldns_admin.erl
@@ -63,6 +63,7 @@ init([]) ->
         [
           {"/", erldns_admin_root_handler, []},
           {"/zones/:name", erldns_admin_zone_resource_handler, []},
+          {"/zones/:zone_name/records/:record_name", erldns_admin_zone_records_resource_handler, []},
           {"/zones/:name/:action", erldns_admin_zone_control_handler, []}
         ]
       }

--- a/src/erldns_admin.erl
+++ b/src/erldns_admin.erl
@@ -62,10 +62,10 @@ init([]) ->
       {'_', 
         [
           {"/", erldns_admin_root_handler, []},
-          {"/zones/:name", erldns_admin_zone_resource_handler, []},
-          {"/zones/:zone_name/records", erldns_admin_zone_records_resource_handler, []},
+          {"/zones/:zone_name", erldns_admin_zone_resource_handler, []},
+          {"/zones/:zone_name/records/", erldns_admin_zone_records_resource_handler, []},
           {"/zones/:zone_name/records/:record_name", erldns_admin_zone_records_resource_handler, []},
-          {"/zones/:name/:action", erldns_admin_zone_control_handler, []}
+          {"/zones/:zone_name/:action", erldns_admin_zone_control_handler, []}
         ]
       }
     ]

--- a/src/erldns_admin_zone_control_handler.erl
+++ b/src/erldns_admin_zone_control_handler.erl
@@ -46,7 +46,7 @@ to_text(Req, State) ->
   {<<"erldns admin">>, Req, State}.
 
 to_json(Req, State) ->
-  Name = cowboy_req:binding(name, Req),
+  Name = cowboy_req:binding(zone_name, Req),
   Action = cowboy_req:binding(action, Req),
   case Action of
     _ ->

--- a/src/erldns_admin_zone_records_resource_handler.erl
+++ b/src/erldns_admin_zone_records_resource_handler.erl
@@ -41,7 +41,7 @@ is_authorized(Req, State) ->
   erldns_admin:is_authorized(Req, State).
 
 resource_exists(Req, State) ->
-  Name = cowboy_req:binding(name, Req),
+  Name = cowboy_req:binding(zone_name, Req),
   {erldns_zone_cache:in_zone(Name), Req, State}.
 
 

--- a/src/erldns_admin_zone_records_resource_handler.erl
+++ b/src/erldns_admin_zone_records_resource_handler.erl
@@ -56,13 +56,12 @@ to_json(Req, State) ->
   RecordName = cowboy_req:binding(record_name, Req, <<"">>),
   Params = cowboy_req:parse_qs(Req),
 
-  lager:debug("Received GET (zone_name: ~p, record_name: ~p)", [ZoneName, RecordName]),
 
   case lists:keyfind(<<"type">>, 1, Params) of
     false ->
-      lager:debug("Type is not specified"),
+      lager:debug("Received GET (zone_name: ~p, record_name: ~p, record_type: unspecified)", [ZoneName, RecordName]),
       {erldns_zone_encoder:zone_records_to_json(ZoneName, RecordName), Req, State};
     {<<"type">>, RecordType} ->
-      lager:debug("Type is specified (type: ~p)", [RecordType]),
+      lager:debug("Received GET (zone_name: ~p, record_name: ~p, record_type: ~p)", [ZoneName, RecordName, RecordType]),
       {erldns_zone_encoder:zone_records_to_json(ZoneName, RecordName, RecordType), Req, State}
   end.

--- a/src/erldns_admin_zone_records_resource_handler.erl
+++ b/src/erldns_admin_zone_records_resource_handler.erl
@@ -1,0 +1,68 @@
+%% Copyright (c) 2012-2020, DNSimple Corporation 
+%%
+%% Permission to use, copy, modify, and/or distribute this software for any
+%% purpose with or without fee is hereby granted, provided that the above
+%% copyright notice and this permission notice appear in all copies.
+%%
+%% THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+%% WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+%% MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+%% ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+%% WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+%% ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+%% OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+%% @doc Cowbow handler that handles Admin API requests to /zones/:name
+-module(erldns_admin_zone_records_resource_handler).
+
+-export([init/2]).
+-export([content_types_provided/2, is_authorized/2, resource_exists/2, allowed_methods/2]).
+-export([to_html/2, to_json/2, to_text/2]).
+
+-behaviour(cowboy_rest).
+
+-include_lib("dns_erlang/include/dns.hrl").
+-include_lib("erldns/include/erldns.hrl").
+
+init(Req, State) ->
+  {cowboy_rest, Req, State}.
+
+allowed_methods(Req, State) ->
+  {[<<"GET">>], Req, State}.
+
+content_types_provided(Req, State) ->
+  {[
+      {<<"text/html">>, to_html},
+      {<<"text/plain">>, to_text},
+      {<<"application/json">>, to_json}
+    ], Req, State}.
+
+is_authorized(Req, State) ->
+  erldns_admin:is_authorized(Req, State).
+
+resource_exists(Req, State) ->
+  Name = cowboy_req:binding(name, Req),
+  {erldns_zone_cache:in_zone(Name), Req, State}.
+
+
+to_html(Req, State) ->
+  {<<"erldns admin">>, Req, State}.
+
+to_text(Req, State) ->
+  {<<"erldns admin">>, Req, State}.
+
+to_json(Req, State) ->
+  ZoneName = cowboy_req:binding(zone_name, Req),
+  RecordName = cowboy_req:binding(record_name, Req),
+  Params = cowboy_req:parse_qs(Req),
+
+  lager:debug("Received GET (zone_name: ~p, record_name: ~p)", [ZoneName, RecordName]),
+
+  case lists:keyfind(<<"type">>, 1, Params) of
+    false ->
+      Records = erldns_zone_cache:get_zone_records_by_name(ZoneName, RecordName),
+      {erldns_zone_encoder:records_to_json(Records), Req, State};
+    {<<"type">>, RecordType} ->
+      Records = erldns_zone_cache:get_zone_records_by_name_and_type(ZoneName, RecordName, RecordType),
+      {erldns_zone_encoder:records_to_json(Records), Req, State}
+  end.

--- a/src/erldns_admin_zone_records_resource_handler.erl
+++ b/src/erldns_admin_zone_records_resource_handler.erl
@@ -60,9 +60,7 @@ to_json(Req, State) ->
 
   case lists:keyfind(<<"type">>, 1, Params) of
     false ->
-      Records = erldns_zone_cache:get_zone_records_by_name(ZoneName, RecordName),
-      {erldns_zone_encoder:records_to_json(Records), Req, State};
+      {erldns_zone_encoder:zone_records_to_json(ZoneName, RecordName), Req, State};
     {<<"type">>, RecordType} ->
-      Records = erldns_zone_cache:get_zone_records_by_name_and_type(ZoneName, RecordName, RecordType),
-      {erldns_zone_encoder:records_to_json(Records), Req, State}
+      {erldns_zone_encoder:zone_records_to_json(ZoneName, RecordName, RecordType), Req, State}
   end.

--- a/src/erldns_admin_zone_records_resource_handler.erl
+++ b/src/erldns_admin_zone_records_resource_handler.erl
@@ -53,14 +53,16 @@ to_text(Req, State) ->
 
 to_json(Req, State) ->
   ZoneName = cowboy_req:binding(zone_name, Req),
-  RecordName = cowboy_req:binding(record_name, Req),
+  RecordName = cowboy_req:binding(record_name, Req, <<"">>),
   Params = cowboy_req:parse_qs(Req),
 
   lager:debug("Received GET (zone_name: ~p, record_name: ~p)", [ZoneName, RecordName]),
 
   case lists:keyfind(<<"type">>, 1, Params) of
     false ->
+      lager:debug("Type is not specified"),
       {erldns_zone_encoder:zone_records_to_json(ZoneName, RecordName), Req, State};
     {<<"type">>, RecordType} ->
+      lager:debug("Type is specified (type: ~p)", [RecordType]),
       {erldns_zone_encoder:zone_records_to_json(ZoneName, RecordName, RecordType), Req, State}
   end.

--- a/src/erldns_admin_zone_resource_handler.erl
+++ b/src/erldns_admin_zone_resource_handler.erl
@@ -41,11 +41,11 @@ is_authorized(Req, State) ->
   erldns_admin:is_authorized(Req, State).
 
 resource_exists(Req, State) ->
-  Name = cowboy_req:binding(name, Req),
+  Name = cowboy_req:binding(zone_name, Req),
   {erldns_zone_cache:in_zone(Name), Req, State}.
 
 delete_resource(Req, State) ->
-  Name = cowboy_req:binding(name, Req),
+  Name = cowboy_req:binding(zone_name, Req),
   lager:debug("Received DELETE for ~p", [Name]),
   erldns_zone_cache:delete_zone(Name),
   {true, Req, State}.

--- a/src/erldns_admin_zone_resource_handler.erl
+++ b/src/erldns_admin_zone_resource_handler.erl
@@ -64,7 +64,7 @@ to_json(Req, State) ->
 
   case lists:keyfind(<<"metaonly">>, 1, Params) of
     false ->
-      case erldns_zone_cache:get_zone_with_records(Name) of
+      case erldns_zone_cache:get_zone(Name) of
         {ok, Zone} ->
           {erldns_zone_encoder:zone_to_json(Zone), Req, State};
         {error, Reason} ->

--- a/src/erldns_admin_zone_resource_handler.erl
+++ b/src/erldns_admin_zone_resource_handler.erl
@@ -58,7 +58,7 @@ to_text(Req, State) ->
   {<<"erldns admin">>, Req, State}.
 
 to_json(Req, State) ->
-  Name = cowboy_req:binding(name, Req),
+  Name = cowboy_req:binding(zone_name, Req),
   Params = cowboy_req:parse_qs(Req),
   lager:debug("Received GET for ~p (params: ~p)", [Name, Params]),
 


### PR DESCRIPTION
Note that these API changes are intended to be completely backwards compatible with the current caller expecations. In the future the zones API will likely change to make meta-only the only behavior, removing the parameter.

Depends on https://github.com/dnsimple/erldns/pull/118

Example of getting only zone metadata:

```
curl -i -u "username:password" "http://localhost:8083/zones/example.com?metaonly=1" -H "Accept:application/json"
HTTP/1.1 200 OK
content-length: 138
content-type: application/json
date: Fri, 23 Oct 2020 14:02:02 GMT
server: Cowboy
vary: accept

{"erldns":{"zone":{"name":"example.com","version":"03f9b1ecc0b8ba95286b0425f39bf5e9607ed9d9eaad121be04f0853c1e79758","records_count":15}}}
```

Example of getting details for records with a specific record name:

```
url -i -u "username:password" "http://localhost:8083/zones/example.com/records/www.example.com" -H "Accept:application/json"
HTTP/1.1 200 OK
content-length: 534
content-type: application/json
date: Sat, 24 Oct 2020 08:58:00 GMT
server: Cowboy
vary: accept

[{"name":"www.example.com.","type":"A","ttl":3600,"content":"4.5.6.7"},{"name":"www.example.com.","type":"RRSIG","ttl":3600,"content":"1 8 3 3600 1610635684 1602859684 41299 <<101,120,97,109,112,108,101,46,99,111,109>> \\�Z�o�����ٸ�\u001f\u001d�U\u0011v�fbм\u0017��Ͻ?\u001a0�ͬ�v\u0000\u001b�ާ�\u001bJ\bP���E��=C4��\u0015\u000b!�5[�(a���ԫ\u0013\u0005\u0014pP蕵F�ƒ��q���\u0017%��m�j:�̿{�-ARBY��\u0006Z\u0014\u001b�\f\u000fg�8hs\u00041E�"}]
```

Example of getting details for records with a specific record name and type:

```
curl -i -u "username:password" "http://localhost:8083/zones/example.com/records/example.com?type=NS" -H "Accept:application/json"
HTTP/1.1 200 OK
content-length: 309
content-type: application/json
date: Sat, 24 Oct 2020 09:02:36 GMT
server: Cowboy
vary: accept

[{"name":"example.com.","type":"NS","ttl":3600,"content":"ns1.dnsimple.com."},{"name":"example.com.","type":"NS","ttl":3600,"content":"ns2.dnsimple.com."},{"name":"example.com.","type":"NS","ttl":3600,"content":"ns3.dnsimple.com."},{"name":"example.com.","type":"NS","ttl":3600,"content":"ns4.dnsimple.com."}]
```