### PR TITLE
Adopt Erlfmt

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,14 +1,25 @@
 %%-*- mode: erlang -*-
 {cover_enabled, true}.
+{erl_opts, [
+    debug_info,
+    fail_on_warning,
+    {parse_transform, lager_transform}
+]}.
 
-{erl_opts, [debug_info, fail_on_warning,
-            {parse_transform, lager_transform}]}.
+{project_plugins, [
+    erlfmt
+]}.
 
-{deps, [{lager, "3.9.2"},
-        folsom,
-        cowboy,
-        jsx,
-        dns_erlang,
-        erldns
-       ]}.
+{deps, [
+    {lager, "3.9.2"},
+    folsom,
+    cowboy,
+    jsx,
+    dns_erlang,
+    erldns
+]}.
 
+{erlfmt, [
+    write,
+    {print_width, 140}
+]}.

--- a/src/erldns_admin.app.src
+++ b/src/erldns_admin.app.src
@@ -1,7 +1,6 @@
-{application, erldns_admin,
- [{description, "Erlang Authoritative DNS Server Admin API"},
-  {vsn, "1.1.0"},
-  {mod, { erldns_admin_app, []}},
-  {applications, [kernel, stdlib, inets, crypto, ssl, observer, bear, folsom, ranch, cowboy, erldns]} 
-  ]}.
-
+{application, erldns_admin, [
+    {description, "Erlang Authoritative DNS Server Admin API"},
+    {vsn, "1.1.0"},
+    {mod, {erldns_admin_app, []}},
+    {applications, [kernel, stdlib, inets, crypto, ssl, observer, bear, folsom, ranch, cowboy, erldns]}
+]}.

--- a/src/erldns_admin_app.erl
+++ b/src/erldns_admin_app.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2019, DNSimple Corporation 
+%% Copyright (c) 2012-2019, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above
@@ -20,9 +20,9 @@
 -export([start/2, stop/1]).
 
 start(_Type, _Args) ->
-  lager:debug("Starting erldns_admin application"),
-  erldns_admin_sup:start_link().
+    lager:debug("Starting erldns_admin application"),
+    erldns_admin_sup:start_link().
 
 stop(_State) ->
-  lager:info("Stop erldns_admin application"),
-  ok.
+    lager:info("Stop erldns_admin application"),
+    ok.

--- a/src/erldns_admin_root_handler.erl
+++ b/src/erldns_admin_root_handler.erl
@@ -22,37 +22,42 @@
 -behaviour(cowboy_rest).
 
 init(Req, State) ->
-  {cowboy_rest, Req, State}.
+    {cowboy_rest, Req, State}.
 
 content_types_provided(Req, State) ->
-  {[
-      {<<"text/html">>, to_html},
-      {<<"text/plain">>, to_text},
-      {<<"application/json">>, to_json}
-    ], Req, State}.
+    {
+        [
+            {<<"text/html">>, to_html},
+            {<<"text/plain">>, to_text},
+            {<<"application/json">>, to_json}
+        ],
+        Req,
+        State
+    }.
 
 is_authorized(Req, State) ->
-  erldns_admin:is_authorized(Req, State).
+    erldns_admin:is_authorized(Req, State).
 
 to_html(Req, State) ->
-  {<<"erldns admin">>, Req, State}.
+    {<<"erldns admin">>, Req, State}.
 
 to_text(Req, State) ->
-  {<<"erldns admin">>, Req, State}.
+    {<<"erldns admin">>, Req, State}.
 
 to_json(Req, State) ->
-  ZoneNamesAndVersionsForJson = lists:map(
-    fun({Name, Version}) -> 
-        [{<<"name">>, Name}, {<<"version">>, Version}]
-    end, erldns_zone_cache:zone_names_and_versions()),
+    ZoneNamesAndVersionsForJson = lists:map(
+        fun({Name, Version}) ->
+            [{<<"name">>, Name}, {<<"version">>, Version}]
+        end,
+        erldns_zone_cache:zone_names_and_versions()
+    ),
 
-  Body = jsx:encode([{<<"erldns">>, 
-        [
-          {<<"zones">>, [
-              {<<"count">>, length(ZoneNamesAndVersionsForJson)},
-              {<<"versions">>, ZoneNamesAndVersionsForJson} 
+    Body = jsx:encode([
+        {<<"erldns">>, [
+            {<<"zones">>, [
+                {<<"count">>, length(ZoneNamesAndVersionsForJson)},
+                {<<"versions">>, ZoneNamesAndVersionsForJson}
             ]}
-        ]
-      }]),
-  {Body, Req, State}.
-
+        ]}
+    ]),
+    {Body, Req, State}.

--- a/src/erldns_admin_sup.erl
+++ b/src/erldns_admin_sup.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2019, DNSimple Corporation 
+%% Copyright (c) 2012-2019, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above
@@ -30,13 +30,12 @@
 %% Public API
 -spec start_link() -> any().
 start_link() ->
-  supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
-
+    supervisor:start_link({local, ?SUPERVISOR}, ?MODULE, []).
 
 %% Callbacks
 init(_Args) ->
-  SysProcs = [
-    ?CHILD(erldns_admin, worker, [])
-  ],
+    SysProcs = [
+        ?CHILD(erldns_admin, worker, [])
+    ],
 
-  {ok, {{one_for_one, 20, 10}, SysProcs}}.
+    {ok, {{one_for_one, 20, 10}, SysProcs}}.

--- a/src/erldns_admin_zone_control_handler.erl
+++ b/src/erldns_admin_zone_control_handler.erl
@@ -27,29 +27,33 @@
 -include_lib("erldns/include/erldns.hrl").
 
 init(Req, State) ->
-  {cowboy_rest, Req, State}.
+    {cowboy_rest, Req, State}.
 
 content_types_provided(Req, State) ->
-  {[
-      {<<"text/html">>, to_html},
-      {<<"text/plain">>, to_text},
-      {<<"application/json">>, to_json}
-    ], Req, State}.
+    {
+        [
+            {<<"text/html">>, to_html},
+            {<<"text/plain">>, to_text},
+            {<<"application/json">>, to_json}
+        ],
+        Req,
+        State
+    }.
 
 is_authorized(Req, State) ->
-  erldns_admin:is_authorized(Req, State).
+    erldns_admin:is_authorized(Req, State).
 
 to_html(Req, State) ->
-  {<<"erldns admin">>, Req, State}.
+    {<<"erldns admin">>, Req, State}.
 
 to_text(Req, State) ->
-  {<<"erldns admin">>, Req, State}.
+    {<<"erldns admin">>, Req, State}.
 
 to_json(Req, State) ->
-  Name = cowboy_req:binding(zone_name, Req),
-  Action = cowboy_req:binding(action, Req),
-  case Action of
-    _ ->
-      lager:debug("Unsupported action: ~p (name: ~p)", [Action, Name]),
-      {jsx:encode([]), Req, State}
-  end.
+    Name = cowboy_req:binding(zone_name, Req),
+    Action = cowboy_req:binding(action, Req),
+    case Action of
+        _ ->
+            lager:debug("Unsupported action: ~p (name: ~p)", [Action, Name]),
+            {jsx:encode([]), Req, State}
+    end.

--- a/src/erldns_admin_zone_records_resource_handler.erl
+++ b/src/erldns_admin_zone_records_resource_handler.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2020, DNSimple Corporation 
+%% Copyright (c) 2012-2020, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above
@@ -25,43 +25,45 @@
 -include_lib("erldns/include/erldns.hrl").
 
 init(Req, State) ->
-  {cowboy_rest, Req, State}.
+    {cowboy_rest, Req, State}.
 
 allowed_methods(Req, State) ->
-  {[<<"GET">>], Req, State}.
+    {[<<"GET">>], Req, State}.
 
 content_types_provided(Req, State) ->
-  {[
-      {<<"text/html">>, to_html},
-      {<<"text/plain">>, to_text},
-      {<<"application/json">>, to_json}
-    ], Req, State}.
+    {
+        [
+            {<<"text/html">>, to_html},
+            {<<"text/plain">>, to_text},
+            {<<"application/json">>, to_json}
+        ],
+        Req,
+        State
+    }.
 
 is_authorized(Req, State) ->
-  erldns_admin:is_authorized(Req, State).
+    erldns_admin:is_authorized(Req, State).
 
 resource_exists(Req, State) ->
-  Name = cowboy_req:binding(zone_name, Req),
-  {erldns_zone_cache:in_zone(Name), Req, State}.
-
+    Name = cowboy_req:binding(zone_name, Req),
+    {erldns_zone_cache:in_zone(Name), Req, State}.
 
 to_html(Req, State) ->
-  {<<"erldns admin">>, Req, State}.
+    {<<"erldns admin">>, Req, State}.
 
 to_text(Req, State) ->
-  {<<"erldns admin">>, Req, State}.
+    {<<"erldns admin">>, Req, State}.
 
 to_json(Req, State) ->
-  ZoneName = cowboy_req:binding(zone_name, Req),
-  RecordName = cowboy_req:binding(record_name, Req, <<"">>),
-  Params = cowboy_req:parse_qs(Req),
+    ZoneName = cowboy_req:binding(zone_name, Req),
+    RecordName = cowboy_req:binding(record_name, Req, <<"">>),
+    Params = cowboy_req:parse_qs(Req),
 
-
-  case lists:keyfind(<<"type">>, 1, Params) of
-    false ->
-      lager:debug("Received GET (zone_name: ~p, record_name: ~p, record_type: unspecified)", [ZoneName, RecordName]),
-      {erldns_zone_encoder:zone_records_to_json(ZoneName, RecordName), Req, State};
-    {<<"type">>, RecordType} ->
-      lager:debug("Received GET (zone_name: ~p, record_name: ~p, record_type: ~p)", [ZoneName, RecordName, RecordType]),
-      {erldns_zone_encoder:zone_records_to_json(ZoneName, RecordName, RecordType), Req, State}
-  end.
+    case lists:keyfind(<<"type">>, 1, Params) of
+        false ->
+            lager:debug("Received GET (zone_name: ~p, record_name: ~p, record_type: unspecified)", [ZoneName, RecordName]),
+            {erldns_zone_encoder:zone_records_to_json(ZoneName, RecordName), Req, State};
+        {<<"type">>, RecordType} ->
+            lager:debug("Received GET (zone_name: ~p, record_name: ~p, record_type: ~p)", [ZoneName, RecordName, RecordType]),
+            {erldns_zone_encoder:zone_records_to_json(ZoneName, RecordName, RecordType), Req, State}
+    end.

--- a/src/erldns_admin_zone_resource_handler.erl
+++ b/src/erldns_admin_zone_resource_handler.erl
@@ -1,4 +1,4 @@
-%% Copyright (c) 2012-2019, DNSimple Corporation 
+%% Copyright (c) 2012-2019, DNSimple Corporation
 %%
 %% Permission to use, copy, modify, and/or distribute this software for any
 %% purpose with or without fee is hereby granted, provided that the above
@@ -25,58 +25,61 @@
 -include_lib("erldns/include/erldns.hrl").
 
 init(Req, State) ->
-  {cowboy_rest, Req, State}.
+    {cowboy_rest, Req, State}.
 
 allowed_methods(Req, State) ->
-  {[<<"GET">>, <<"DELETE">>], Req, State}.
+    {[<<"GET">>, <<"DELETE">>], Req, State}.
 
 content_types_provided(Req, State) ->
-  {[
-      {<<"text/html">>, to_html},
-      {<<"text/plain">>, to_text},
-      {<<"application/json">>, to_json}
-    ], Req, State}.
+    {
+        [
+            {<<"text/html">>, to_html},
+            {<<"text/plain">>, to_text},
+            {<<"application/json">>, to_json}
+        ],
+        Req,
+        State
+    }.
 
 is_authorized(Req, State) ->
-  erldns_admin:is_authorized(Req, State).
+    erldns_admin:is_authorized(Req, State).
 
 resource_exists(Req, State) ->
-  Name = cowboy_req:binding(zone_name, Req),
-  {erldns_zone_cache:in_zone(Name), Req, State}.
+    Name = cowboy_req:binding(zone_name, Req),
+    {erldns_zone_cache:in_zone(Name), Req, State}.
 
 delete_resource(Req, State) ->
-  Name = cowboy_req:binding(zone_name, Req),
-  lager:debug("Received DELETE for ~p", [Name]),
-  erldns_zone_cache:delete_zone(Name),
-  {true, Req, State}.
-
+    Name = cowboy_req:binding(zone_name, Req),
+    lager:debug("Received DELETE for ~p", [Name]),
+    erldns_zone_cache:delete_zone(Name),
+    {true, Req, State}.
 
 to_html(Req, State) ->
-  {<<"erldns admin">>, Req, State}.
+    {<<"erldns admin">>, Req, State}.
 
 to_text(Req, State) ->
-  {<<"erldns admin">>, Req, State}.
+    {<<"erldns admin">>, Req, State}.
 
 to_json(Req, State) ->
-  Name = cowboy_req:binding(zone_name, Req),
-  Params = cowboy_req:parse_qs(Req),
-  lager:debug("Received GET for ~p (params: ~p)", [Name, Params]),
+    Name = cowboy_req:binding(zone_name, Req),
+    Params = cowboy_req:parse_qs(Req),
+    lager:debug("Received GET for ~p (params: ~p)", [Name, Params]),
 
-  case lists:keyfind(<<"metaonly">>, 1, Params) of
-    false ->
-      case erldns_zone_cache:get_zone(Name) of
-        {ok, Zone} ->
-          {erldns_zone_encoder:zone_to_json(Zone), Req, State};
-        {error, Reason} ->
-          lager:error("Error getting zone: ~p", [Reason]),
-          {halt, cowboy_req:reply(400, [], io_lib:format("Error getting zone: ~p", [Reason]), Req), State}
-      end;
-    _ ->
-      case erldns_zone_cache:get_zone(Name) of
-        {ok, Zone} ->
-          {erldns_zone_encoder:zone_meta_to_json(Zone), Req, State};
-        {error, Reason} ->
-          lager:error("Error getting zone: ~p", [Reason]),
-          {halt, cowbow_req:reply(400, [], io_lib:format("Error getting zone: ~p", [Reason]), Req), State}
-      end
-  end.
+    case lists:keyfind(<<"metaonly">>, 1, Params) of
+        false ->
+            case erldns_zone_cache:get_zone(Name) of
+                {ok, Zone} ->
+                    {erldns_zone_encoder:zone_to_json(Zone), Req, State};
+                {error, Reason} ->
+                    lager:error("Error getting zone: ~p", [Reason]),
+                    {halt, cowboy_req:reply(400, [], io_lib:format("Error getting zone: ~p", [Reason]), Req), State}
+            end;
+        _ ->
+            case erldns_zone_cache:get_zone(Name) of
+                {ok, Zone} ->
+                    {erldns_zone_encoder:zone_meta_to_json(Zone), Req, State};
+                {error, Reason} ->
+                    lager:error("Error getting zone: ~p", [Reason]),
+                    {halt, cowbow_req:reply(400, [], io_lib:format("Error getting zone: ~p", [Reason]), Req), State}
+            end
+    end.


### PR DESCRIPTION
This is an attempt to define some consistent formatting rules for our Erlang code.

I made some research and I tested various options, so far the one that I prefer is [erlfmt](https://github.com/WhatsApp/erlfmt) from WhatsApp. Like most non-builtin formatters, this is opinionated. But the choices they made are well thought, and seem to be a good starting point.


You have both the option to reformat the code inline:

```
rebar3 fmt
```

or check the formatting:

```
rebar3 fmt --check
```

This last command is especially useful for CI integration.
