### PR TITLE
Support IPv6 (OTP 26)

### DIFF
--- a/src/erldns_admin.erl
+++ b/src/erldns_admin.erl
@@ -71,7 +71,7 @@ init([]) ->
         ]
     ),
 
-    {ok, _} = cowboy:start_clear(?MODULE, [{port, port()}], #{env => #{dispatch => Dispatch}}),
+    {ok, _} = cowboy:start_clear(?MODULE, [inet, inet6, {port, port()}], #{env => #{dispatch => Dispatch}}),
 
     {ok, #state{}}.
 


### PR DESCRIPTION
This PR launches the cowboy server binding to IPv4 and IPv6 on the same port. This change is targeting OTP 26 version of the library as OTP 27 branches are still under development.

This PR is not expected to be merged into `main`.