### PR TITLE
Adds YAMLlint and markdownlint 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+---
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -9,3 +11,4 @@ updates:
     labels:
       - task
       - dependencies
+      - automerge

--- a/.github/workflows/check_deps.yml
+++ b/.github/workflows/check_deps.yml
@@ -1,3 +1,5 @@
+---
+
 name: Check Dependencies
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  markdownlint-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run markdownlint-cli
+        uses: nosborn/github-action-markdown-cli@v3.4.0
+        with:
+          files: .
+          config_file: ".markdownlint.yaml"
+
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run YAML Lint
+        uses: actionshub/yamllint@main
+
   build:
     name: Build
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
+---
+
 name: CI
 
 on:
   pull_request:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
       matrix:
         otp_version: ['27.1']
 
+    needs:
+      - build
+      - markdownlint-cli
+      - yamllint
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,13 @@
+---
+default: true
+
+# no-hard-tabs
+MD010:
+  code_blocks: false
+
+# no-multiple-blanks
+MD012:
+  maximum: 2
+
+# line-length
+MD013: false

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 256
+    level: warning
+  truthy:
+    ignore: |
+      /.github/workflows/*.yml


### PR DESCRIPTION
This PR adds YAML and Markdown linters config and make them run in the CI Github Action.

This is an effort on standardizing our Erlang repositories.

## :shipit: Deploy Steps

- [x] Just merge, no need to cut a release for this

## :shipit: Verification Steps

- [x] CI passing while executing YAML and Markdown linters
