### PR TITLE
Task/updates contributing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,5 @@
+---
+
 version: 2
 updates:
   - package-ecosystem: "github-actions"
@@ -9,3 +11,4 @@ updates:
     labels:
       - task
       - dependencies
+      - automerge

--- a/.github/workflows/check_deps.yml
+++ b/.github/workflows/check_deps.yml
@@ -1,3 +1,5 @@
+---
+
 name: Check Dependencies
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  markdownlint-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run markdownlint-cli
+        uses: nosborn/github-action-markdown-cli@v3.4.0
+        with:
+          files: .
+          config_file: ".markdownlint.yaml"
+
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+      - name: Run YAML Lint
+        uses: actionshub/yamllint@main
+
   build:
     name: Build
     runs-on: ubuntu-22.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,12 @@
+---
+
 name: CI
 
 on:
   pull_request:
   push:
-    branches: [ "main" ]
+    branches:
+      - main
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
       matrix:
         otp_version: ['27.1']
 
+    needs:
+      - build
+      - markdownlint-cli
+      - yamllint
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+---
+
+name: Release
+
+on:
+  push:
+    tags:
+      - v*.*.*
+
+jobs:
+  publish:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@v4
+
+      - name: Publish to Hex.pm
+        uses: erlangpack/github-action@v3
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,13 @@
+---
+default: true
+
+# no-hard-tabs
+MD010:
+  code_blocks: false
+
+# no-multiple-blanks
+MD012:
+  maximum: 2
+
+# line-length
+MD013: false

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 256
+    level: warning
+  truthy:
+    ignore: |
+      /.github/workflows/*.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## main
+
+## 1.0.0
+
+### Changed
+
+- Bumps to OTP/27
+- Replaced "jsx" with "json"
+
+### Added
+
+- erlfmt
+- CONTRIBUTING.md
+- CHANGELOG.md
+- release process to hex.pm

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to erldns-admin
+
+## Getting started
+
+### 1. Clone the repository
+
+Clone the repository and move into it:
+
+```shell
+git clone git@github.com:dnsimple/erldns-admin.git
+cd erldns-admin
+```
+
+### 2. Install Erlang
+
+### 3. Install the dependencies
+
+```shell
+make
+```
+
+#### Updating Dependencies
+
+When dependencies are updated the rebar.lock file will need to be updated for the new dependency to be used. The following command does this:
+
+```shell
+./rebar3 upgrade --all
+```
+
+## Formatting
+
+If your editor doesn't automatically format Erlang code using [erlfmt](https://github.com/WhatsApp/erlfmt), run:
+
+```shell
+make format
+```
+
+You should run this command before releasing.
+
+### 3. Build and test
+
+Compile the project and [run the test suite](#testing) to check everything works as expected.
+
+## Testing
+
+```shell
+make test
+```
+
+## Releasing
+
+The following instructions uses `$VERSION` as a placeholder, where `$VERSION` is a `MAJOR.MINOR.BUGFIX` release such as `1.2.0`.
+
+1. Run the test suite and ensure all the tests pass.
+
+1. Set the version in `src/erldns_admin.app.src`
+
+1. Run the test suite and ensure all the tests pass.
+
+1. Finalize the `## main` section in `CHANGELOG.md` assigning the version.
+
+1. Commit and push the changes
+
+    ```shell
+    git commit -a -m "Release $VERSION"
+    git push origin main
+    ```
+
+1. Wait for CI to complete.
+
+1. Create a signed tag.
+
+    ```shell
+    git tag -a v$VERSION -s -m "Release $VERSION"
+    git push origin --tags
+    ```
+
+1. GitHub actions will take it from there and release to <https://hex.pm/packages/erldns_admin>
+
+## Tests
+
+Submit unit tests for your changes. You can test your changes on your machine by [running the test suite](#testing).
+
+When you submit a PR, tests will also be run on the [continuous integration environment via GitHub Actions](https://github.com/dnsimple/dnsimple-ruby/actions/workflows/ci.yml).

--- a/README.md
+++ b/README.md
@@ -2,17 +2,20 @@
 
 This app provides an admin API for querying and controlling an erldns server.
 
+[![Build Status](https://github.com/dnsimple/erldns-admin/actions/workflows/ci.yml/badge.svg)](https://github.com/dnsimple/erldns-admin/actions/workflows/ci.yml)
+[![Module Version](https://img.shields.io/hexpm/v/erldns-admin.svg)](https://hex.pm/packages/erldns-admin)
+
 ## Building
 
 To build:
 
-```bash
+```shell
 make
 ```
 
 To start fresh:
 
-```bash
+```shell
 make fresh
 ```
 
@@ -20,7 +23,7 @@ make fresh
 
 To start the HTTP server, run:
 
-```bash
+```shell
 rebar3 shell
 ```
 
@@ -28,6 +31,6 @@ rebar3 shell
 
 If your editor doesn't automatically format Erlang code using [erlfmt](https://github.com/WhatsApp/erlfmt), run:
 
-```bash
+```shell
 make format
 ```

--- a/src/erldns_admin.app.src
+++ b/src/erldns_admin.app.src
@@ -1,6 +1,7 @@
 {application, erldns_admin, [
     {description, "Erlang Authoritative DNS Server Admin API"},
-    {vsn, "1.1.0"},
+    {vsn, "1.0.0"},
     {mod, {erldns_admin_app, []}},
-    {applications, [kernel, stdlib, inets, crypto, ssl, observer, bear, folsom, ranch, cowboy, erldns]}
+    {applications, [kernel, stdlib, inets, crypto, ssl, observer, bear, folsom, ranch, cowboy, erldns]},
+    {links, [{"GitHub", "https://github.com/dnsimple/erldns-admin"}]}
 ]}.


### PR DESCRIPTION
This PR adds the release process to https://hex.pm/packages/erldns-admin

This is an effort on standardizing our Erlang repositories.

## :shipit: Deploy Steps

- [ ] https://github.com/dnsimple/erldns-admin/pull/23
- [ ] https://github.com/dnsimple/erldns-admin/pull/24
- [ ] Add `HEX_API_KEY` secret
- [ ] Merge
- [ ] Follow ./CONTRIBUTING.md guide to cut a 1.0.0 release

## :shipit: Verification Steps

- [ ] CI passing
- [ ] 1.0.0 is released to https://hex.pm/packages/erldns-admin
